### PR TITLE
feat: auto-merge based on multiple checks with status comment

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,11 +17,14 @@ var loadedPlugins []plugins.Plugin
 
 func runPluginOnProject(client *gitlab.Client, project *gitlab.Project) {
 	for _, plugin := range loadedPlugins {
+		log.Debug("running plugin", plugin)
 		plugin.Execute(project)
 	}
 }
 
 func loop(client *gitlab.Client) {
+	log.Debug("starting loop ...")
+
 	p := &gitlab.ListProjectsOptions{}
 	projects, _, err := client.Projects.ListProjects(p)
 	if err != nil {

--- a/plugins/auto_merge/README.md
+++ b/plugins/auto_merge/README.md
@@ -1,0 +1,5 @@
+# Plugin: auto-merge
+
+> This plugin checks merge-requests for some requirements. If requirements are unresolved it comments the current status of all checks in the merge-request. If all checks pass this plugin automatically merges them into the target branch.
+
+## Config

--- a/plugins/auto_merge/auto_merge.go
+++ b/plugins/auto_merge/auto_merge.go
@@ -13,8 +13,8 @@ type AutoMergePlugin struct {
 
 func (plugin AutoMergePlugin) Execute(project *gitlab.Project) {
 	opt := &gitlab.ListProjectMergeRequestsOptions{
-		State:  gitlab.String("opened"),
-		Labels: []string{"👀 Ready for Review"},
+		State: gitlab.String("opened"),
+		// Labels: []string{"👀 Ready for Review"},
 	}
 
 	mergeRequests, _, err := plugin.Client.MergeRequests.ListProjectMergeRequests(project.ID, opt)

--- a/plugins/auto_merge/auto_merge.go
+++ b/plugins/auto_merge/auto_merge.go
@@ -32,6 +32,8 @@ func (plugin AutoMergePlugin) autoMerge(project *gitlab.Project, mergeRequest *g
 
 	status := plugin.checkMergeRequest(project, mergeRequest)
 	if status.hasConflicts != mergeStatusSuccess ||
+		status.hasNeededLabels != mergeStatusSuccess ||
+		status.isNotWorkInProgress != mergeStatusSuccess ||
 		status.openDicussions != mergeStatusSuccess ||
 		status.passingPipeline != mergeStatusSuccess ||
 		status.enoughApprovals != mergeStatusSuccess {

--- a/plugins/auto_merge/checks/has_enough_approvals.go
+++ b/plugins/auto_merge/checks/has_enough_approvals.go
@@ -1,0 +1,32 @@
+package checks
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/xanzy/go-gitlab"
+)
+
+type HasEnoughApprovalsCheck struct {
+}
+
+func (check HasEnoughApprovalsCheck) Check(client *gitlab.Client, project *gitlab.Project, mergeRequest *gitlab.MergeRequest) bool {
+	approvals, _, err := client.MergeRequests.GetMergeRequestApprovals(project.ID, mergeRequest.IID)
+
+	if err != nil {
+		log.Error("Can't load merge-request approvals", err)
+		return false
+	}
+
+	return len(approvals.ApprovedBy) >= 1
+}
+
+func (plugin HasEnoughApprovalsCheck) Name() string {
+	return "has-enough-approvals"
+}
+
+func (plugin HasEnoughApprovalsCheck) PassedText() string {
+	return "Enough reviewers liked your changes"
+}
+
+func (plugin HasEnoughApprovalsCheck) FailedText() string {
+	return "You still need some review for your changes"
+}

--- a/plugins/auto_merge/checks/has_labels.go
+++ b/plugins/auto_merge/checks/has_labels.go
@@ -1,0 +1,42 @@
+package checks
+
+import (
+	"github.com/xanzy/go-gitlab"
+)
+
+type HasRequiredLabelsCheck struct {
+}
+
+func (check HasRequiredLabelsCheck) Check(client *gitlab.Client, project *gitlab.Project, mergeRequest *gitlab.MergeRequest) bool {
+	neededLabels := [...]string{"👀 Ready for Review"}
+
+	for _, neededLabel := range neededLabels {
+		if !check.hasMergeRequestLabel(mergeRequest, neededLabel) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (plugin HasRequiredLabelsCheck) Name() string {
+	return "has-labels"
+}
+
+func (plugin HasRequiredLabelsCheck) PassedText() string {
+	return "Your Merge-Request has all required labels"
+}
+
+func (plugin HasRequiredLabelsCheck) FailedText() string {
+	return "Your Merge-Request is missing some required labels" // TODO list missing labels
+}
+
+func (plugin HasRequiredLabelsCheck) hasMergeRequestLabel(mergeRequest *gitlab.MergeRequest, searchedLabel string) bool {
+	for _, label := range mergeRequest.Labels {
+		if searchedLabel == label {
+			return true
+		}
+	}
+
+	return false
+}

--- a/plugins/auto_merge/checks/has_no_conflicts.go
+++ b/plugins/auto_merge/checks/has_no_conflicts.go
@@ -1,0 +1,24 @@
+package checks
+
+import (
+	"github.com/xanzy/go-gitlab"
+)
+
+type HasNoConflictsCheck struct {
+}
+
+func (check HasNoConflictsCheck) Check(client *gitlab.Client, project *gitlab.Project, mergeRequest *gitlab.MergeRequest) bool {
+	return !mergeRequest.HasConflicts
+}
+
+func (plugin HasNoConflictsCheck) Name() string {
+	return "has-conflicts"
+}
+
+func (plugin HasNoConflictsCheck) PassedText() string {
+	return "Your changes do not have conflicts with the target branch."
+}
+
+func (plugin HasNoConflictsCheck) FailedText() string {
+	return "Your changes have some conflicts with the target branch"
+}

--- a/plugins/auto_merge/checks/has_no_open_discussions.go
+++ b/plugins/auto_merge/checks/has_no_open_discussions.go
@@ -1,0 +1,24 @@
+package checks
+
+import (
+	"github.com/xanzy/go-gitlab"
+)
+
+type HasNoOpenDiscussionsCheck struct {
+}
+
+func (check HasNoOpenDiscussionsCheck) Check(client *gitlab.Client, project *gitlab.Project, mergeRequest *gitlab.MergeRequest) bool {
+	return mergeRequest.BlockingDiscussionsResolved
+}
+
+func (plugin HasNoOpenDiscussionsCheck) Name() string {
+	return "has-no-open-discussions"
+}
+
+func (plugin HasNoOpenDiscussionsCheck) PassedText() string {
+	return "All discussions about your changes have been resolved"
+}
+
+func (plugin HasNoOpenDiscussionsCheck) FailedText() string {
+	return "There are still some ongoing discussions about your changes"
+}

--- a/plugins/auto_merge/checks/is_not_work_in_progress.go
+++ b/plugins/auto_merge/checks/is_not_work_in_progress.go
@@ -1,0 +1,24 @@
+package checks
+
+import (
+	"github.com/xanzy/go-gitlab"
+)
+
+type IsNotWorkInProgressCheck struct {
+}
+
+func (check IsNotWorkInProgressCheck) Check(client *gitlab.Client, project *gitlab.Project, mergeRequest *gitlab.MergeRequest) bool {
+	return !mergeRequest.WorkInProgress
+}
+
+func (plugin IsNotWorkInProgressCheck) Name() string {
+	return "is-not-work-in-progress"
+}
+
+func (plugin IsNotWorkInProgressCheck) PassedText() string {
+	return "Your Merge-Request is marked as ready (no WIP-prefix)"
+}
+
+func (plugin IsNotWorkInProgressCheck) FailedText() string {
+	return "Your Merge-Request is not ready yet (marked with WIP-prefix)"
+}

--- a/plugins/auto_merge/checks/passes_ci.go
+++ b/plugins/auto_merge/checks/passes_ci.go
@@ -1,0 +1,32 @@
+package checks
+
+import (
+	log "github.com/sirupsen/logrus"
+
+	"github.com/xanzy/go-gitlab"
+)
+
+type PassesCICheck struct {
+}
+
+func (check PassesCICheck) Check(client *gitlab.Client, project *gitlab.Project, mergeRequest *gitlab.MergeRequest) bool {
+	pipelines, _, err := client.MergeRequests.ListMergeRequestPipelines(project.ID, mergeRequest.IID)
+	if err != nil {
+		log.Error("Can't load merge-request pipelines", err)
+		return false
+	}
+
+	return pipelines[0].Status == "success"
+}
+
+func (plugin PassesCICheck) Name() string {
+	return "passes-ci"
+}
+
+func (plugin PassesCICheck) PassedText() string {
+	return "A pipline successfully tested your changes"
+}
+
+func (plugin PassesCICheck) FailedText() string {
+	return "A pipeline detected some errors with your changes"
+}

--- a/plugins/auto_merge/merge_checks.go
+++ b/plugins/auto_merge/merge_checks.go
@@ -1,0 +1,78 @@
+package auto_merge
+
+import (
+	"log"
+
+	"github.com/xanzy/go-gitlab"
+)
+
+type mergeStatusLevel int
+
+const (
+	mergeStatusSkipped mergeStatusLevel = iota
+	mergeStatusSuccess mergeStatusLevel = iota
+	mergeStatusFailed  mergeStatusLevel = iota
+)
+
+type mergeStatus struct {
+	hasConflicts    mergeStatusLevel
+	openDicussions  mergeStatusLevel
+	enoughApprovals mergeStatusLevel
+	passingPipeline mergeStatusLevel
+}
+
+func equalMergeStatus(mergeStatusA *mergeStatus, mergeStatusB *mergeStatus) bool {
+	return mergeStatusA.hasConflicts == mergeStatusB.hasConflicts &&
+		mergeStatusA.openDicussions == mergeStatusB.openDicussions &&
+		mergeStatusA.passingPipeline == mergeStatusB.passingPipeline &&
+		mergeStatusA.enoughApprovals == mergeStatusB.enoughApprovals
+}
+
+func (plugin AutoMergePlugin) checkMergeRequest(project *gitlab.Project, mergeRequest *gitlab.MergeRequest) *mergeStatus {
+	status := &mergeStatus{
+		openDicussions:  mergeStatusSkipped,
+		enoughApprovals: mergeStatusSkipped,
+		passingPipeline: mergeStatusSkipped,
+		hasConflicts:    mergeStatusSkipped,
+	}
+
+	// has conflicts
+	status.hasConflicts = mergeStatusFailed
+	if mergeRequest.HasConflicts {
+		return status
+	}
+	status.hasConflicts = mergeStatusSuccess
+
+	// open discussions
+	status.openDicussions = mergeStatusFailed
+	if !mergeRequest.BlockingDiscussionsResolved {
+		return status
+	}
+	status.openDicussions = mergeStatusSuccess
+
+	// passing ci
+	status.enoughApprovals = mergeStatusFailed
+	approvals, _, err := plugin.Client.MergeRequests.GetMergeRequestApprovals(project.ID, mergeRequest.IID)
+	if err != nil {
+		log.Println("Can't load merge-request approvals", err)
+		return status
+	}
+	if len(approvals.ApprovedBy) < 1 {
+		return status
+	}
+	status.enoughApprovals = mergeStatusSuccess
+
+	// enough approvals
+	status.passingPipeline = mergeStatusFailed
+	pipelines, _, err := plugin.Client.MergeRequests.ListMergeRequestPipelines(project.ID, mergeRequest.IID)
+	if err != nil {
+		log.Println("Can't load merge-request pipelines", err)
+		return status
+	}
+	if pipelines[0].Status != "success" {
+		return status
+	}
+	status.passingPipeline = mergeStatusSuccess
+
+	return status
+}

--- a/plugins/auto_merge/merge_checks.go
+++ b/plugins/auto_merge/merge_checks.go
@@ -1,8 +1,7 @@
 package auto_merge
 
 import (
-	"log"
-
+	log "github.com/sirupsen/logrus"
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -86,7 +85,7 @@ func (plugin AutoMergePlugin) checkMergeRequest(project *gitlab.Project, mergeRe
 		status.enoughApprovals = mergeStatusFailed
 
 		if err != nil {
-			log.Println("Can't load merge-request approvals", err)
+			log.Error("Can't load merge-request approvals", err)
 		}
 	}
 
@@ -96,7 +95,7 @@ func (plugin AutoMergePlugin) checkMergeRequest(project *gitlab.Project, mergeRe
 		status.passingPipeline = mergeStatusSuccess
 	} else {
 		if err != nil {
-			log.Println("Can't load merge-request pipelines", err)
+			log.Error("Can't load merge-request pipelines", err)
 		}
 
 		status.passingPipeline = mergeStatusFailed

--- a/plugins/auto_merge/merge_status.go
+++ b/plugins/auto_merge/merge_status.go
@@ -3,6 +3,7 @@ package auto_merge
 import (
 	"regexp"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -83,7 +84,7 @@ func (plugin AutoMergePlugin) getStatusComment(project *gitlab.Project, mergeReq
 }
 
 func (plugin AutoMergePlugin) saveStatusComment(project *gitlab.Project, mergeRequest *gitlab.MergeRequest, comment string, note *gitlab.Note) {
-	// log.Println("comment", comment)
+	log.Debug("comment", comment)
 
 	// update existing note
 	if note != nil {

--- a/plugins/auto_merge/merge_status.go
+++ b/plugins/auto_merge/merge_status.go
@@ -44,7 +44,7 @@ func encodeMergeStatus(status *mergeStatus) string {
 	comment = comment + "- " + getMergeStatusLevelEmojis(status.openDicussions) + " All discussions about your changes have been resolved\n"
 	comment = comment + "- " + getMergeStatusLevelEmojis(status.passingPipeline) + " A pipline successfully tested your code\n"
 	comment = comment + "- " + getMergeStatusLevelEmojis(status.enoughApprovals) + " Enough reviewers liked your code\n"
-	comment = comment + "---\nI am [Lassie](@lassie) :dog: and I will watch you progress from time to time to auto merge your changes once finished.\n"
+	comment = comment + "---\nI am [Lassie](@lassie) :dog: and I will watch your progress from time to time to auto merge your changes once finished.\n"
 
 	return comment
 }

--- a/plugins/auto_merge/merge_status.go
+++ b/plugins/auto_merge/merge_status.go
@@ -13,10 +13,10 @@ func encodeMergeCheckStatus(mergeCheck mergeCheck, status *mergeStatus) string {
 	for _, mergeCheckResult := range status.checkResults {
 		if mergeCheckResult.mergeCheckName == mergeCheck.Name() {
 			if mergeCheckResult.mergeCheckPassed {
-				return "- :green_heart: " + mergeCheck.PassedText()
+				return "- :green_heart: " + mergeCheck.PassedText() + "\n"
 			} else {
 				// :collision: :exclamation:
-				return "- :poop: " + mergeCheck.FailedText()
+				return "- :poop: " + mergeCheck.FailedText() + "\n"
 			}
 		}
 	}

--- a/plugins/auto_merge/merge_status.go
+++ b/plugins/auto_merge/merge_status.go
@@ -9,63 +9,44 @@ import (
 
 const authorTag = "<!-- author:lassie-bot-dog -->"
 
-func getMergeStatusLevelEmojis(mergeStatusLevel mergeStatusLevel) string {
-	if mergeStatusLevel == mergeStatusSuccess {
-		return ":green_heart:"
+func encodeMergeCheckStatus(mergeCheck mergeCheck, status *mergeStatus) string {
+	for _, mergeCheckResult := range status.checkResults {
+		if mergeCheckResult.mergeCheckName == mergeCheck.Name() {
+			if mergeCheckResult.mergeCheckPassed {
+				return "- :green_heart: " + mergeCheck.PassedText()
+			} else {
+				// :collision: :exclamation:
+				return "- :poop: " + mergeCheck.FailedText()
+			}
+		}
 	}
 
-	if mergeStatusLevel == mergeStatusFailed {
-		return ":poop:" // :collision: :exclamation:
-	}
-
-	// mergeStatusLevel == mergeStatusSkipped
-	return ":hourglass_flowing_sand:"
+	return ""
 }
 
-// func decodeMergeStatus(comment string) *mergeStatus {
-// 	// TODO
-// 	hasConflicts := mergeStatusFailed
-// 	openDicussions := mergeStatusSkipped
-// 	passingPipeline := mergeStatusSkipped
-// 	enoughApprovals := mergeStatusSkipped
-
-// 	return &mergeStatus{
-// 		hasConflicts:    hasConflicts,
-// 		openDicussions:  openDicussions,
-// 		passingPipeline: passingPipeline,
-// 		enoughApprovals: enoughApprovals,
-// 	}
-// }
-
-func encodeMergeStatus(status *mergeStatus) string {
+func (plugin AutoMergePlugin) encodeMergeStatus(status *mergeStatus) string {
 	comment := authorTag + "\n"
-	comment = comment + "### Your current merge request status is:\n\n"
-	comment = comment + "- " + getMergeStatusLevelEmojis(status.hasNeededLabels) + " Your merge request has all needed labels to be auto-merged\n"
-	comment = comment + "- " + getMergeStatusLevelEmojis(status.isNotWorkInProgress) + " Your merge request is marked as ready (removed WIP: prefix)\n"
-	comment = comment + "- " + getMergeStatusLevelEmojis(status.hasConflicts) + " Your changes do not have conflicts with the target branch\n"
-	comment = comment + "- " + getMergeStatusLevelEmojis(status.openDicussions) + " All discussions about your changes have been resolved\n"
-	comment = comment + "- " + getMergeStatusLevelEmojis(status.passingPipeline) + " A pipline successfully tested your code\n"
-	comment = comment + "- " + getMergeStatusLevelEmojis(status.enoughApprovals) + " Enough reviewers liked your code\n"
-	comment = comment + "---\nI am [Lassie](@lassie) :dog: and I will watch your progress from time to time to auto merge your changes once finished.\n"
+
+	if status.merged {
+		comment = comment + ":dog: Thank you for your contribution. Always nice to have some helping hands :feet:"
+		comment = comment + "---\n"
+		comment = comment + "I am [Lassie](@lassie) :dog: and I help with some housekeeping tasks.\n"
+	} else {
+		comment = comment + "### Your current merge request status is:\n\n"
+		for _, mergeCheck := range plugin.mergeChecks() {
+			comment = comment + encodeMergeCheckStatus(mergeCheck, status)
+		}
+		comment = comment + "---\n"
+		comment = comment + "I am [Lassie](@lassie) :dog: and I will watch your progress from time to time to auto merge your changes once finished.\n"
+	}
 
 	return comment
 }
 
 func (plugin AutoMergePlugin) updateStatusComment(project *gitlab.Project, mergeRequest *gitlab.MergeRequest, status *mergeStatus) {
-	comment := ""
 	note := plugin.getStatusComment(project, mergeRequest)
-	// if note != nil {
-	// 	comment = note.Body
-	// }
-
-	// lastStatus := decodeMergeStatus(comment)
-
-	// if lastStatus == nil || !equalMergeStatus(status, lastStatus) {
-	comment = encodeMergeStatus(status)
+	comment := plugin.encodeMergeStatus(status)
 	plugin.saveStatusComment(project, mergeRequest, comment, note)
-	// } else {
-	// 	log.Println("skip")
-	// }
 }
 
 func (plugin AutoMergePlugin) getStatusComment(project *gitlab.Project, mergeRequest *gitlab.MergeRequest) *gitlab.Note {

--- a/plugins/auto_merge/merge_status.go
+++ b/plugins/auto_merge/merge_status.go
@@ -1,0 +1,101 @@
+package auto_merge
+
+import (
+	"log"
+	"regexp"
+
+	"github.com/xanzy/go-gitlab"
+)
+
+const authorTag = "<!-- author:lassie-bot-dog -->"
+
+func getMergeStatusLevelEmojis(mergeStatusLevel mergeStatusLevel) string {
+	if mergeStatusLevel == mergeStatusSuccess {
+		return ":green_heart:"
+	}
+
+	if mergeStatusLevel == mergeStatusFailed {
+		return ":poop:" // :collision: :exclamation:
+	}
+
+	// mergeStatusLevel == mergeStatusSkipped
+	return ":hourglass_flowing_sand:"
+}
+
+func decodeMergeStatus(comment string) *mergeStatus {
+	// TODO
+	hasConflicts := mergeStatusFailed
+	openDicussions := mergeStatusSkipped
+	passingPipeline := mergeStatusSkipped
+	enoughApprovals := mergeStatusSkipped
+
+	return &mergeStatus{
+		hasConflicts:    hasConflicts,
+		openDicussions:  openDicussions,
+		passingPipeline: passingPipeline,
+		enoughApprovals: enoughApprovals,
+	}
+}
+
+func encodeMergeStatus(status *mergeStatus) string {
+	comment := authorTag + "\n"
+	comment = comment + "### Your current merge request status is:\n\n"
+	comment = comment + "- " + getMergeStatusLevelEmojis(status.hasConflicts) + " Your changes do not have conflicts with the target branch\n"
+	comment = comment + "- " + getMergeStatusLevelEmojis(status.openDicussions) + " All discussions about your changes have been resolved\n"
+	comment = comment + "- " + getMergeStatusLevelEmojis(status.passingPipeline) + " A pipline successfully tested your code\n"
+	comment = comment + "- " + getMergeStatusLevelEmojis(status.enoughApprovals) + " Enough reviewers liked your code\n"
+	comment = comment + "---\nI am [Lassie](@lassie) :dog: and I will watch you progress from time to time to auto merge your changes once finished.\n"
+
+	return comment
+}
+
+func (plugin AutoMergePlugin) updateStatusComment(project *gitlab.Project, mergeRequest *gitlab.MergeRequest, status *mergeStatus) {
+	comment := ""
+	note := plugin.getStatusComment(project, mergeRequest)
+	if note != nil {
+		comment = note.Body
+	}
+
+	lastStatus := decodeMergeStatus(comment)
+
+	if lastStatus == nil || !equalMergeStatus(status, lastStatus) {
+		comment = encodeMergeStatus(status)
+		plugin.saveStatusComment(project, mergeRequest, comment, note)
+	} else {
+		log.Println("skip")
+	}
+}
+
+func (plugin AutoMergePlugin) getStatusComment(project *gitlab.Project, mergeRequest *gitlab.MergeRequest) *gitlab.Note {
+	listMergeRequestNotesOptions := &gitlab.ListMergeRequestNotesOptions{}
+	notes, _, _ := plugin.Client.Notes.ListMergeRequestNotes(project.ID, mergeRequest.IID, listMergeRequestNotesOptions)
+
+	r, _ := regexp.Compile("^" + authorTag + ".*?")
+
+	for _, note := range notes {
+		if !note.System && r.MatchString(note.Body) {
+			return note
+		}
+	}
+
+	return nil
+}
+
+func (plugin AutoMergePlugin) saveStatusComment(project *gitlab.Project, mergeRequest *gitlab.MergeRequest, comment string, note *gitlab.Note) {
+	log.Println("comment", comment)
+
+	// update existing note
+	if note != nil {
+		updateMergeRequestNoteOptions := &gitlab.UpdateMergeRequestNoteOptions{
+			Body: gitlab.String(comment),
+		}
+		plugin.Client.Notes.UpdateMergeRequestNote(project.ID, mergeRequest.IID, note.ID, updateMergeRequestNoteOptions)
+		return
+	}
+
+	createMergeRequestNoteOptions := &gitlab.CreateMergeRequestNoteOptions{
+		Body: gitlab.String(comment),
+	}
+	plugin.Client.Notes.CreateMergeRequestNote(project.ID, mergeRequest.IID, createMergeRequestNoteOptions)
+
+}

--- a/plugins/auto_merge/merge_status.go
+++ b/plugins/auto_merge/merge_status.go
@@ -1,7 +1,6 @@
 package auto_merge
 
 import (
-	"log"
 	"regexp"
 
 	"github.com/xanzy/go-gitlab"
@@ -22,24 +21,26 @@ func getMergeStatusLevelEmojis(mergeStatusLevel mergeStatusLevel) string {
 	return ":hourglass_flowing_sand:"
 }
 
-func decodeMergeStatus(comment string) *mergeStatus {
-	// TODO
-	hasConflicts := mergeStatusFailed
-	openDicussions := mergeStatusSkipped
-	passingPipeline := mergeStatusSkipped
-	enoughApprovals := mergeStatusSkipped
+// func decodeMergeStatus(comment string) *mergeStatus {
+// 	// TODO
+// 	hasConflicts := mergeStatusFailed
+// 	openDicussions := mergeStatusSkipped
+// 	passingPipeline := mergeStatusSkipped
+// 	enoughApprovals := mergeStatusSkipped
 
-	return &mergeStatus{
-		hasConflicts:    hasConflicts,
-		openDicussions:  openDicussions,
-		passingPipeline: passingPipeline,
-		enoughApprovals: enoughApprovals,
-	}
-}
+// 	return &mergeStatus{
+// 		hasConflicts:    hasConflicts,
+// 		openDicussions:  openDicussions,
+// 		passingPipeline: passingPipeline,
+// 		enoughApprovals: enoughApprovals,
+// 	}
+// }
 
 func encodeMergeStatus(status *mergeStatus) string {
 	comment := authorTag + "\n"
 	comment = comment + "### Your current merge request status is:\n\n"
+	comment = comment + "- " + getMergeStatusLevelEmojis(status.hasNeededLabels) + " Your merge request has all needed labels to be auto-merged\n"
+	comment = comment + "- " + getMergeStatusLevelEmojis(status.isNotWorkInProgress) + " Your merge request is marked as ready (removed WIP: prefix)\n"
 	comment = comment + "- " + getMergeStatusLevelEmojis(status.hasConflicts) + " Your changes do not have conflicts with the target branch\n"
 	comment = comment + "- " + getMergeStatusLevelEmojis(status.openDicussions) + " All discussions about your changes have been resolved\n"
 	comment = comment + "- " + getMergeStatusLevelEmojis(status.passingPipeline) + " A pipline successfully tested your code\n"
@@ -52,18 +53,18 @@ func encodeMergeStatus(status *mergeStatus) string {
 func (plugin AutoMergePlugin) updateStatusComment(project *gitlab.Project, mergeRequest *gitlab.MergeRequest, status *mergeStatus) {
 	comment := ""
 	note := plugin.getStatusComment(project, mergeRequest)
-	if note != nil {
-		comment = note.Body
-	}
+	// if note != nil {
+	// 	comment = note.Body
+	// }
 
-	lastStatus := decodeMergeStatus(comment)
+	// lastStatus := decodeMergeStatus(comment)
 
-	if lastStatus == nil || !equalMergeStatus(status, lastStatus) {
-		comment = encodeMergeStatus(status)
-		plugin.saveStatusComment(project, mergeRequest, comment, note)
-	} else {
-		log.Println("skip")
-	}
+	// if lastStatus == nil || !equalMergeStatus(status, lastStatus) {
+	comment = encodeMergeStatus(status)
+	plugin.saveStatusComment(project, mergeRequest, comment, note)
+	// } else {
+	// 	log.Println("skip")
+	// }
 }
 
 func (plugin AutoMergePlugin) getStatusComment(project *gitlab.Project, mergeRequest *gitlab.MergeRequest) *gitlab.Note {
@@ -82,7 +83,7 @@ func (plugin AutoMergePlugin) getStatusComment(project *gitlab.Project, mergeReq
 }
 
 func (plugin AutoMergePlugin) saveStatusComment(project *gitlab.Project, mergeRequest *gitlab.MergeRequest, comment string, note *gitlab.Note) {
-	log.Println("comment", comment)
+	// log.Println("comment", comment)
 
 	// update existing note
 	if note != nil {


### PR DESCRIPTION
![Screenshot from 2021-05-22 09-56-11](https://user-images.githubusercontent.com/6918444/119219099-fc68c800-bae3-11eb-836e-39912d37426b.png)

# TODO
- [ ] ~~parse current comment and get status out of it~~ for now we just "spam" gitlab
- [x] separate merge checks in individual files
- [x] add plugin readme

# Checks
- [ ] specific reviewers approved if a specific label has been applied
- [ ] a merge-request template has been used
- [x] pipeline passes
- [x] no open conversations
- [x] someone approved
- [x] has needed labels
- [x] has no file conflicts
- [x] is not work-in-progress