### PR TITLE
fix: load merge-request from ref if pipeline updated

### DIFF
--- a/plugins/auto_merge/auto_merge_test.go
+++ b/plugins/auto_merge/auto_merge_test.go
@@ -1,0 +1,33 @@
+package auto_merge_test
+
+import (
+	"testing"
+
+	"github.com/GEPROG/lassie-bot-dog/plugins/auto_merge"
+)
+
+func TestIsRefMergeRequest(t *testing.T) {
+	ref := "refs/merge-requests/50/head"
+	if !auto_merge.IsRefMergeRequest(ref) {
+		t.Error()
+	}
+
+	ref = "refs/main"
+	if auto_merge.IsRefMergeRequest(ref) {
+		t.Error()
+	}
+}
+
+func TestGetMergeRequestIdFromRef(t *testing.T) {
+	ref := "refs/merge-requests/50/head"
+	mergeRequestIID, err := auto_merge.GetMergeRequestIdFromRef(ref)
+	if mergeRequestIID != 50 || err != nil {
+		t.Error()
+	}
+
+	ref = "refs/main"
+	mergeRequestIID, err = auto_merge.GetMergeRequestIdFromRef(ref)
+	if mergeRequestIID != -1 || err == nil {
+		t.Error()
+	}
+}


### PR DESCRIPTION
The ref of a pipeline wasn't containing the pure branch name, but the number of the merge-request in a format like: `refs/merge-requests/50/head`.  As searching for the source-branch with that ref was wrong, we know test if a pipeline uses that specific ref type and then extract the id out of it to query the MR by that id.