### PR TITLE
fix: use notes endpoint to check for unresolved discussions

### DIFF
--- a/plugins/auto_merge/checks/has_no_open_discussions.go
+++ b/plugins/auto_merge/checks/has_no_open_discussions.go
@@ -19,7 +19,7 @@ func (check HasNoOpenDiscussionsCheck) Check(_ *config.AutoMergeConfig, _ *gitla
 	}
 	for _, note := range notes {
 		if note.Resolvable && !note.Resolved {
-			log.Debug("Found unresolved discussion", mergeRequest.ProjectID, mergeRequest.IID, note.ID)
+			log.Debug("Found unresolved discussion", note.ID)
 			return false
 		}
 	}

--- a/plugins/auto_merge/checks/has_no_open_discussions.go
+++ b/plugins/auto_merge/checks/has_no_open_discussions.go
@@ -2,16 +2,16 @@ package checks
 
 import (
 	"github.com/GEPROG/lassie-bot-dog/plugins/auto_merge/config"
+	"github.com/GEPROG/lassie-bot-dog/utils"
 	"github.com/xanzy/go-gitlab"
-
-	log "github.com/sirupsen/logrus"
 )
 
 type HasNoOpenDiscussionsCheck struct {
 	Client *gitlab.Client
 }
 
-func (check HasNoOpenDiscussionsCheck) Check(_ *config.AutoMergeConfig, _ *gitlab.Project, mergeRequest *gitlab.MergeRequest) bool {
+func (check HasNoOpenDiscussionsCheck) Check(_ *config.AutoMergeConfig, project *gitlab.Project, mergeRequest *gitlab.MergeRequest) bool {
+	log := utils.Logger(project, mergeRequest)
 	notes, _, err := check.Client.Notes.ListMergeRequestNotes(mergeRequest.ProjectID, mergeRequest.IID, nil)
 	if err != nil {
 		log.Error("Can't load merge-request notes", err)

--- a/plugins/auto_merge/merge_checks.go
+++ b/plugins/auto_merge/merge_checks.go
@@ -68,7 +68,7 @@ func (plugin AutoMergePlugin) setupMergeChecks() {
 		},
 		checks.HasRequiredLabelsCheck{},
 		checks.HasNoConflictsCheck{},
-		checks.HasNoOpenDiscussionsCheck{},
+		checks.HasNoOpenDiscussionsCheck{Client: plugin.Client},
 		checks.IsNotWorkInProgressCheck{},
 		checks.PassesCICheck{
 			Client: plugin.Client,

--- a/plugins/auto_merge/merge_status.go
+++ b/plugins/auto_merge/merge_status.go
@@ -109,7 +109,7 @@ func (plugin AutoMergePlugin) saveStatusComment(project *gitlab.Project, mergeRe
 		}
 		_, _, err := plugin.Client.Notes.UpdateMergeRequestNote(project.ID, mergeRequest.IID, note.ID, updateMergeRequestNoteOptions)
 		if err != nil {
-			log.Error("Failed to update merge request note")
+			log.Error("Failed to update merge request note (" + mergeRequest.WebURL + ")")
 		}
 
 		log.Debug("update comment")


### PR DESCRIPTION
The merge request property is unreliable for some reason.