### PR TITLE
fix: skip archived projects

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ func loop(client *gitlab.Client) {
 		// Search: gitlab.String("lassie-test"),
 		Membership: gitlab.Bool(true), // only list projects that lassie is a member of
 		Sort:       gitlab.String("asc"),
+		Archived:   gitlab.Bool(false), // only list unarchived projects
 	}
 
 	for {


### PR DESCRIPTION
Lassie also considered archived projects and since you can not add or change comments in archived projects this always throws errors.

This PR is there to ignore archived projects